### PR TITLE
Adding info on supported Python versions

### DIFF
--- a/_products/bw1094.md
+++ b/_products/bw1094.md
@@ -21,7 +21,8 @@ The Raspberry Pi HAT Edition allows using the Raspberry Pi you already have and 
 
 ## Requirements
 
-A RaspberryPi with an extended 40-pin GPIO Header.
+* A RaspberryPi with an extended 40-pin GPIO Header.
+* Python 3.7
 
 ## Board Layout
 

--- a/_products/bw1098ffc.md
+++ b/_products/bw1098ffc.md
@@ -22,7 +22,7 @@ Use DepthAI on your existing host. Since the AI/vision processing is done on the
   * [Stereo camera pair](/products/stereo_camera_pair/) (if depth is required)
 * USB3C cable
 * USB3C port on the host
-* Python 3 installed on host
+* Python 3.6 installed on host
 
 ## Board Layout
 

--- a/_products/bw1098ffc.md
+++ b/_products/bw1098ffc.md
@@ -22,7 +22,7 @@ Use DepthAI on your existing host. Since the AI/vision processing is done on the
   * [Stereo camera pair](/products/stereo_camera_pair/) (if depth is required)
 * USB3C cable
 * USB3C port on the host
-* Python 3.6 installed on host
+* [A supported Python version](/api/#python_version) on the host
 
 ## Board Layout
 

--- a/_products/bw1098obc.md
+++ b/_products/bw1098obc.md
@@ -20,7 +20,7 @@ Use DepthAI on your existing host. Since the AI/vision processing is done on the
 * Ubuntu 18.04 or Raspbian 10
 * USB3C cable
 * USB3C port on the host
-* Python 3.6 installed on host
+* [A supported Python version](/api/#python_version) on the host
 
 {: #in_box}
 ## What's in the box?

--- a/_products/bw1098obc.md
+++ b/_products/bw1098obc.md
@@ -20,7 +20,7 @@ Use DepthAI on your existing host. Since the AI/vision processing is done on the
 * Ubuntu 18.04 or Raspbian 10
 * USB3C cable
 * USB3C port on the host
-* Python 3 installed on host
+* Python 3.6 installed on host
 
 {: #in_box}
 ## What's in the box?

--- a/api.md
+++ b/api.md
@@ -10,6 +10,14 @@ order: 5
 
 Instructions for installing, upgrading, and using the DepthAI Python API.
 
+{: #python_version data-toc-title="Python Versions"}
+## Supported Python Versions
+
+The DepthAI API requires the following Python versions:
+
+* Ubuntu - Python 3.6
+* Raspbian - Python 3.7
+
 <h2 id="install" data-toc-title="Installation">Installing the DepthAI API</h2>
 
 <div class="alert alert-primary" role="alert">
@@ -21,8 +29,6 @@ error
 </div>
 
 The DepthAI Python Module and extras (utilities, examples, and tutorials) are installed by checking out our [depthai-python-extras](https://github.com/luxonis/depthai-python-extras) GitHub repository. This will change to a standard `pip install` in the future.
-
-The DepthAI API requires Python 3.
 
 To get started:
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -17,7 +17,7 @@ rm /home/pi/.config/autostart/runai.desktop
 <hr/>
 
 {: #device_reset data-toc-title="Reset the Myriad X"}
-### I'm seeing `depthai: Error initalizing xlink` errors and DepthAI fails to run.
+### `depthai: Error initalizing xlink` errors and DepthAI fails to run.
 
 The Myriad X needs to be reset. Click the "MODULE RST" or "RST" button on your carrier board.
 
@@ -29,6 +29,22 @@ raspi-gpio set 33 dh  # drive high to reset Myriad X
 sleep 1
 raspi-gpio set 33 dl  # drive low to allow Myriad X to run
 ```
+
+<hr/>
+
+{: #depthai_import_error}
+### ImportError: No module named 'depthai'
+
+This indicates that the `depthai.*.so` file could not be loaded. There are a handful of reasons this can fail:
+
+1. Is the DepthAI API [installed](api/#install)? Verify that it appears when you type:
+    ```
+    pip3 list | grep depthai
+    ```
+2. Are you using a [supported Python version](/api/#python_version) for your operating system? Check that your Python version is [supported](/api/#python_version):
+    ```
+    python3 --version
+    ```
 
 <hr/>
 


### PR DESCRIPTION
The `depthai*.so` file requires specific Python versions based on the OS. This clarifies version support. 