### PR TITLE
Attempting to set canonical url to https://docs.luxonis.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title:
 email:
 author:
 description:
-url:
+url: https://docs.luxonis.com
 kramdown:
   parse_block_html: true
 highlighter: rouge

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,8 @@
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/main.css">
 
+   <link rel="canonical" href="{{site.url}}{{page.url}}" />
+
   <!-- Open Graph data -->
   {% if page.og_image_path %}
     <meta property="og:image" content="https://docs.luxonis.com{{ page.og_image_path }}">


### PR DESCRIPTION
While working on #18 , looks like Netlify preview urls and/or the original url was indexed.

Via Google Search Console:

![image](https://user-images.githubusercontent.com/7880/75729199-57c45580-5ca7-11ea-8137-5a1968ffa604.png)

This attempts to set it via a rel="canonical" link tag (https://support.google.com/webmasters/answer/139066).