### PR TITLE
Add install scripts to Python API instructions

### DIFF
--- a/api.md
+++ b/api.md
@@ -18,8 +18,8 @@ For other operating systems and/or Python versions, DepthAI can be [built from s
 
 ## Installing system dependencies
 
-Couple of basic system dependencies are required to run the DepthAI library. Most of them should be already installed
-in most of the systems, but in case they are not, we prepared an install script that will make sure all dependencies are installed
+A couple of basic system dependencies are required to run the DepthAI library. Most of them should be already installed
+in most of the systems, but in case they are not, we prepared an install script that will make sure all dependencies are installed:
 
 ```
 curl -fL http://docs.luxonis.com/install_dependencies.sh | bash

--- a/api.md
+++ b/api.md
@@ -16,6 +16,17 @@ Instructions for installing, upgrading, and using the DepthAI Python API.
 The DepthAI API python module is prebuilt for Ubuntu, MaxOS and Windows. 
 For other operating systems and/or Python versions, DepthAI can be [built from source](#compile_api).
 
+## Installing system dependencies
+
+Couple of basic system dependencies are required to run the DepthAI library. Most of them should be already installed
+in most of the systems, but in case they are not, we prepared an install script that will make sure all dependencies are installed
+
+```
+curl -fL http://docs.luxonis.com/install_dependencies.sh | bash
+```
+
+If using Windows, please use [this batch script](/install_dependencies.bat) for dependencies installation 
+
 ## Enabling the USB device
 
 Since the DepthAI is a USB device, in order to communicate with it on the systems that use `udev` tool, you
@@ -26,16 +37,6 @@ The following command will add a new udev rule to your system
 ```
 echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' | sudo tee /etc/udev/rules.d/80-movidius.rules
 sudo udevadm control --reload-rules && sudo udevadm trigger
-```
-
-## Installing system dependencies
-
-Couple of basic system dependencies are required to run the DepthAI library. Most of them should be already installed
-in most of the systems, but in case they are not, use the following instructions to install them
-
-```
-sudo apt-get update
-sudo apt-get install -y python3 python3-pip git cmake libusb-1.0-0-dev build-essential
 ```
 
 ## Install from PyPi


### PR DESCRIPTION
Changed the "Install system dependencies" section, not to use apt-get, but our install script.

Install scripts now support both Windows, Mac and Linux. Their goal is to install all system dependencies, so that user can later install requirements.txt and it won't fail (mainly we had issues due to OpenCV missing libraries, all of them are installed now with the script)