### PR TITLE
Update install_dependencies.sh for macOS, add M1 support

### DIFF
--- a/source/pages/api.rst
+++ b/source/pages/api.rst
@@ -21,11 +21,11 @@ macOS
 
 .. code-block:: bash
 
-  sudo curl -fL http://docs.luxonis.com/_static/install_dependencies.sh | bash
+  bash -c "$(curl -fL http://docs.luxonis.com/_static/install_dependencies.sh)"
   
-Close and re-open thr terminal somdow after this command.
+Close and re-open the terminal window after this command.
   
-Have an M1 Mac?  See `here <https://github.com/luxonis/depthai/issues/299#issuecomment-757110966>`__ for some additional steps that are required until HomeBrew is fully natively supported on M1 macOS.
+The script also works on M1 Macs, Homebrew being installed under Rosetta 2, as some Python packages are still missing native M1 support.  In case you already have Homebrew installed natively and things don't work, see `here <https://github.com/luxonis/depthai/issues/299#issuecomment-757110966>`__ for some additional troubleshooting steps.
   
 Raspberry Pi OS
 ***************


### PR DESCRIPTION
Changed install command to be similar with the Homebrew one:
```diff
-    sudo curl -fL http://docs.luxonis.com/_static/install_dependencies.sh | bash
+    bash -c "$(curl -fL http://docs.luxonis.com/_static/install_dependencies.sh)"
```
As piping through bash caused problems with getting user input:
- needed for agreeing to Rosetta 2 license.
- for the fallback method for installing Xcode tools in Homebrew (GUI install, waiting for the user to press `Enter` when finished), in case the direct install method failed (I encountered that few times on fresh install on M1 Big Sur, possibly some issue with macOS `softwareupdate` or some timing).

Tested on clean install (after erase) of:
- Catalina 10.15 on Mac mini with Intel CPU: the install steps are similar as outlined in the existing Youtube video. There's a password prompt just after the script is started, and everything is still automatic.
- Big Sur 11.1 on Mac mini with Apple M1: running directly on Terminal (arm64 native mode), it checks if Rosetta is installed, and if not it triggers the install, the user just have to press `A` `Enter` to agree to license. And there's one more potential prompt for Xcode fallback install method. Then after finished, the user just have to reopen the terminal, and installing depthai should just work. 