### PR TITLE
removing misplaced heading from FAQ

### DIFF
--- a/source/pages/faq.rst
+++ b/source/pages/faq.rst
@@ -663,9 +663,6 @@ The minimum baseline is set simply by how close the two boards can be spaced bef
 .. image:: /_static/images/faq/modular-stereo-cam-min-dist.png
   :alt: Jetson Tx2
 
-Stereo Neural Inference Mode
-----------------------------
-
 For any stereo baseline under 29cm, the minimum depth is dictated by the hyperfocal distance (the distance above which objects are in focus) of 19.6cm.
 
 For stereo baselines wider than 29cm, the minimum depth is limited by the horizontal field of view (HFOV):


### PR DESCRIPTION
## Removed the heading like in that picture 

![Selection_002](https://user-images.githubusercontent.com/64262095/107523816-6c96b200-6bb5-11eb-84cb-011e8619d285.jpg)
