### PR TITLE
Add a new navbar

### DIFF
--- a/source/_static/css/navbar.css
+++ b/source/_static/css/navbar.css
@@ -21,15 +21,7 @@
     z-index: 100;
 }
 
-.lux-navbar {
-    margin-right: auto;
-    margin-left: auto;
-    padding-left: 15px;
-    padding-right: 15px;
-}
-
 .lux-navbar ul {
-    float: left;
     vertical-align: middle;
 }
 
@@ -101,4 +93,9 @@ div[role=search] {
 
 .wy-side-nav-search a {
     color: #404040;
+}
+
+.lux-navbar-container .lux-navbar {
+    max-width: 1100px;
+    text-align: center;
 }

--- a/source/_static/css/navbar.css
+++ b/source/_static/css/navbar.css
@@ -1,0 +1,100 @@
+
+.cta-row-short h5 {
+    margin-bottom: 0;
+}
+
+#lux-global-navbar {
+    top: 0px;
+    background: #434c6b;
+}
+
+#lux-doc-navbar {
+    top: 78px;
+    background: #7d86a8;
+}
+
+.lux-navbar-container {
+    padding: 1.5em 0;
+    width: 100%;
+    height: auto;
+    overflow: auto;
+    z-index: 100;
+}
+
+.lux-navbar {
+    margin-right: auto;
+    margin-left: auto;
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
+.lux-navbar ul {
+    float: left;
+    vertical-align: middle;
+}
+
+.lux-navbar ul > li {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.lux-navbar a {
+    padding: 8px 13px;
+    color: #b4b7c4;
+}
+
+.lux-navbar a > img {
+    max-width: 110px;
+    max-height: 30px;
+    vertical-align: middle;
+}
+
+.lux-navbar .lux-navbar-active {
+    color: white;
+    font-weight: bold;
+}
+
+.wy-nav-side {
+    top: 146px;
+    background: #eeeeee;
+}
+
+.sticky {
+    top: 0;
+}
+
+#version {
+    color: white;
+}
+
+div[role=search] {
+    margin-top: 1em;
+}
+
+.wy-side-nav-search {
+    background-color: #eeeeee;
+}
+
+.wy-nav-top {
+    background-color: #eeeeee;
+}
+
+.wy-menu-vertical li ul li a {
+ color:#404040;
+}
+.wy-menu-vertical a {
+ color:#404040
+}
+.wy-menu-vertical a:hover {
+ background-color:#cccccc;
+}
+.wy-menu-vertical a:hover span.toctree-expand {
+ color:#404040
+}
+.wy-menu-vertical a:active {
+ background-color:#2980B9;
+ color:#fff
+}
+.wy-menu-vertical a:active span.toctree-expand {
+ color:#fff
+}

--- a/source/_static/css/navbar.css
+++ b/source/_static/css/navbar.css
@@ -14,7 +14,7 @@
 }
 
 .lux-navbar-container {
-    padding: 1.5em 0;
+    padding: 1.5em 1em;
     width: 100%;
     height: auto;
     overflow: auto;
@@ -97,5 +97,4 @@ div[role=search] {
 
 .lux-navbar-container .lux-navbar {
     max-width: 1100px;
-    text-align: center;
 }

--- a/source/_static/css/navbar.css
+++ b/source/_static/css/navbar.css
@@ -98,3 +98,7 @@ div[role=search] {
 .wy-menu-vertical a:active span.toctree-expand {
  color:#fff
 }
+
+.wy-side-nav-search a {
+    color: #404040;
+}

--- a/source/_static/js/navbar.js
+++ b/source/_static/js/navbar.js
@@ -1,0 +1,71 @@
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    'use strict';
+    if (typeof start !== 'number') {
+      start = 0;
+    }
+
+    if (start + search.length > this.length) {
+      return false;
+    } else {
+      return this.indexOf(search, start) !== -1;
+    }
+  };
+}
+
+function addNavbar() {
+  var navbarHtml = "" +
+    "  <div id=\"lux-global-navbar\" class=\"lux-navbar-container\">\n" +
+    "    <div class=\"lux-navbar\">\n" +
+    "      <ul>\n" +
+    "        <li><a href=\"https://luxonis.com\">\n" +
+    "          <img src=\"https://discuss.luxonis.com/assets/logo-fuhmgk6r.png\" alt=\"Luxonis\">\n" +
+    "        </a></li>\n" +
+    "        <li><a href=\"https://luxonis.com/depthai\">Solutions</a></li>\n" +
+    "        <li><a href=\"https://luxonis.com/about\">About</a></li>\n" +
+    "        <li><a href=\"https://discuss.luxonis.com/\">Discuss</a></li>\n" +
+    "        <li><a href=\"https://luxonis.com/jobs\">Jobs</a></li>\n" +
+    "        <li><a href=\"https://docs.luxonis.com/\" class=\"lux-navbar-active\">Docs</a></li>\n" +
+    "      </ul>\n" +
+    "    </div>\n" +
+    "  </div>\n" +
+    "  <div id=\"lux-doc-navbar\" class=\"lux-navbar-container\">\n" +
+    "    <div class=\"lux-navbar\">\n" +
+    "      <ul>\n" +
+    "        <li><a href=\"/\">Main</a></li>\n" +
+    "        <li><a href=\"/projects/api/\">API</a></li>\n" +
+    "        <li><a href=\"/projects/gui/\">GUI</a></li>\n" +
+    "      </ul>\n" +
+    "    </div>\n" +
+    "  </div>"
+  document.body.insertAdjacentHTML( 'afterbegin', navbarHtml );
+}
+
+function adjustNavbarPosition() {
+  var navbar = document.getElementsByClassName("wy-nav-side")[0];
+  var offset = 146 - window.pageYOffset;
+  if (offset >= 0) {
+    navbar.style.top = offset + "px";
+  } else {
+    navbar.style.top = 0 + "px";
+  }
+}
+
+window.onscroll = adjustNavbarPosition
+
+window.onload = function(){
+  addNavbar()
+  adjustNavbarPosition()
+  document.getElementsByClassName("wy-side-scroll")[0].scrollTop = 0;
+  if (location.pathname.startsWith("/projects")) {
+    var links = document.querySelectorAll("#lux-doc-navbar a[href^='/projects']");
+    for (var i = 0; i < links.length; i++) {
+      if(location.pathname.includes(links[i].pathname)) {
+        links[i].classList.add('lux-navbar-active')
+      }
+    }
+  } else {
+    var main = document.querySelector("#lux-doc-navbar a:not([href^='/projects'])")
+    main.classList.add('lux-navbar-active')
+  }
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -64,6 +64,10 @@ html_logo = "_static/images/logo.png"
 html_favicon = '_static/images/favicon.png'
 html_css_files = [
     'css/index.css',
+    'css/navbar.css',
+]
+html_js_files = [
+    'js/navbar.js',
 ]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
The preview is available here - https://docs.luxonis.com/en/nav_header/
![image](https://user-images.githubusercontent.com/5244214/107975043-c59c8680-6fb7-11eb-8089-7918cf733b0e.png)

This PR adds two files: `navbar.css` and `navbar.js`, which together are responsible for creating a navbar visible above - this way it is looking like the headers available on other sites.

After this PR is merged, both of these files will be available as static assets and accessible directly, so any subprojects, like API, will be using the deployed versions of navbar files - and this way, if we change this navbar here, we won't have to update any of the subprojects