### PR TITLE
Disable CI fail when warning is detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W
+SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
After this PR is merged, the CI won't fail if warning is triggered, like

```
Warning, treated as error:
/home/runner/work/depthai-docs-website/depthai-docs-website/source/pages/faq.rst:485:Title underline too short.

On our Roadmap (Most are in development/integration)
***********************************************
```
[Link](https://github.com/luxonis/depthai-docs-website/runs/1965855900?check_suite_focus=true)

These do not interfere with build at all, as the CI actions are only helpers and are not building the site itself