### PR TITLE
Update pretrained_openvino.rst

### DIFF
--- a/source/pages/tutorials/pretrained_openvino.rst
+++ b/source/pages/tutorials/pretrained_openvino.rst
@@ -123,6 +123,17 @@ The flow we walked through works for other pre-trained object detection models i
 - person detection for retail environments (:code:`person-detection-retail-0013`)
 - vehicle detection for driver-assistance (:code:`vehicle-detection-adas-0002`)
 - vehicle and license plate detection (:code:`vehicle-license-plate-detection-barrier-0106`)
+- Human Pose Estimation (:code:`human-pose-estimation-0001`)
+- Pedestrian Detection (ADAS) (:code:`pedestrian-detection-adas-0002`)
+- Person, Vehicle and Bike Detection (:code:`person-vehicle-bike-detection-crossroad-1016`)
+- Age and Gender Recognition (:code:`age-gender-recognition-retail-0013`)
+- Pose Estimation on MobileNetV2 (:code:`mobileNetV2-PoseEstimation`)
+
+Models that can be deployed as first CNN in the argument (:code:`python3 depthai_demo.py -cnn <model>)
+(:code:`vehicle-detection-adas-0002,mobileNetV2-PoseEstimation,yolo-v3,vehicle-license-plate-detection-barrier-0106,age-gender-recognition-retail-0013,person-detection-retail-0013,human-pose-estimation-0001,face-detection-adas-0001,person-vehicle-bike-detection-crossroad-1016,openpose2,pedestrian-detection-adas-0002,tiny-yolo-v3,openpose,deeplabv3p_person,mobilenet-ssd,face-detection-retail-0004`)
+
+Models that can be deployed as second CNN in the argument (:code:`python3 depthai_demo.py -cnn <model_1> -cnn2 <model_2>`)
+(:code:`landmarks-regression-retail-0009,facial-landmarks-35-adas-0002,emotions-recognition-retail-0003`)
 
 Simply change the paths above to run the other models there, adding the correct labels (or funny ones, should you choose).
 


### PR DESCRIPTION
Added models examples to docs relating to this given at  https://github.com/luxonis/depthai/tree/main/resources/nn. Also added doc for models to be passed as first cnn (`-cnn `) and second cnn (`-cnn2`)
All the examples added are from the depthai repo and are tested and verified again (Date - 1st March 2021) on armv7l system machine. No errors reported on execution.