### PR TITLE
Remove docs version from page header

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -21,10 +21,6 @@ project = 'DepthAI Docs'
 copyright = '2020, Luxonis'
 author = 'Luxonis'
 
-# The full version, including alpha/beta/rc tags
-release = '0.3.0.0'
-
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/source/conf.py
+++ b/source/conf.py
@@ -71,5 +71,6 @@ html_css_files = [
 html_js_files = [
     'js/navbar.js',
 ]
+html_title = 'DepthAI documentation | Luxonis'
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
After this PR is merged, the page title will change from

```
DepthAI’s documentation — DepthAI Docs 0.3.0.0 documentation
```

to 

```
DepthAI’s documentation — DepthAI Docs documentation
```

as we don't version the main section of the documentation (each of the submodules is versioned separately).
Deployed version is here - https://docs.luxonis.com/en/remove_version/

