### PR TITLE
Update invalid depth value from 65535 to 0

### DIFF
--- a/source/pages/faq.rst
+++ b/source/pages/faq.rst
@@ -573,7 +573,7 @@ For DepthAI, the HFOV of the the grayscale global shutter cameras is 73.5 degree
   focal_length = 1280/(2*tan(73.5/2/180*pi)) = 857.06
 
 Calculation `here <https://www.google.com/search?safe=off&sxsrf=ALeKk01DFgdNHlMBEkcIJdWmArcgB8Afzg%3A1607995029124&ei=lQ7YX6X-Bor_-gSo7rHIAg&q=1280%2F%282*tan%2873.5%2F2%2F180*pi%29%29&oq=1280%2F%282*tan%2873.5%2F2%2F180*pi%29%29&gs_lcp=CgZwc3ktYWIQAzIECCMQJzoECAAQR1D2HljILmDmPWgAcAJ4AIABywGIAZMEkgEFNC4wLjGYAQCgAQGqAQdnd3Mtd2l6yAEFwAEB&sclient=psy-ab&ved=0ahUKEwjlnIuk6M7tAhWKv54KHSh3DCkQ4dUDCA0&uact=5>`__
-(and for disparity depth data, the value is stored in :code:`uint16`, where the max value of :code:`uint16` of 65535 is a special value, meaning that that distance is unknown.)
+(and for disparity depth data, the value is stored in :code:`uint16`, where 0 is a special value, meaning that distance is unknown.)
 
 How Does DepthAI Calculate Disparity Depth?
 *******************************************


### PR DESCRIPTION
In latest gen2 library it was changed to 0.