### PR TITLE
Add libusb dependency; required to build from sources

### DIFF
--- a/source/_static/install_dependencies.sh
+++ b/source/_static/install_dependencies.sh
@@ -16,6 +16,7 @@ readonly linux_pkgs=(
 
 readonly ubuntu_pkgs=(
     ${linux_pkgs[@]}
+    libusb-1.0-0-dev
     # https://docs.opencv.org/master/d7/d9f/tutorial_linux_install.html
     build-essential
     libgtk2.0-dev


### PR DESCRIPTION
Will be required for https://github.com/luxonis/depthai-python/pull/166 if wheels are not built for current commit. (Local build will be performed which requires libusb)