### PR TITLE
Update dependencies to new released versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/sphinx-doc/sphinx.git@8bf84167a30aa05886fcc1ed8895c8c20e939d89
-sphinx-rtd-theme==0.5.0
-git+git://github.com/VanDavv/rtd-redirects.git@7d4b8a53abbc9985db4e5ee8d27c6671c35c5e30
+Sphinx==3.5.3
+sphinx-rtd-theme==0.5.2
+rtd-redirects==1.1.0
 sphinxcontrib-spelling


### PR DESCRIPTION
Couple of dependencies we had got their new versions, that were only available on github. Now we can use the PyPi ones, which also come with multiple fixes