### PR TITLE
Fix menu style

### DIFF
--- a/source/_static/css/index.css
+++ b/source/_static/css/index.css
@@ -157,6 +157,25 @@ video {
     padding: 10px 15px;
 }
 
-a.reference[href='#ecosystem'] span {
+.toctree-l3 {
     display: none;
+}
+
+.wy-side-scroll .wy-menu-vertical .current:first-child {
+    background: inherit;
+}
+
+.wy-side-scroll .wy-menu-vertical .current:first-child a {
+    color: #404040;
+    border: none;
+    background: inherit;
+    font-weight: normal;
+}
+
+.wy-side-scroll .wy-menu-vertical .current:first-child ul .current a span {
+    display: none;
+}
+
+.wy-side-scroll .wy-menu-vertical .current:first-child .current {
+    background: inherit;
 }

--- a/source/pages/training.rst
+++ b/source/pages/training.rst
@@ -81,6 +81,3 @@ Below is a quick test of the model produced with this notebook on Luxonis DepthA
 This notebook operates on your set of images in Google Drive to resize them to the format needed by the training notebooks.
 
 .. include::  /pages/includes/footer-short.rst
-
-.. include::  /pages/includes/footer-short.rst
-

--- a/source/pages/troubleshooting.rst
+++ b/source/pages/troubleshooting.rst
@@ -137,7 +137,7 @@ So make sure to unplug and then plug the DepthAI back in after having run these.
 CTRL-C Is Not Stopping It!
 ##########################
 
-If you are trying to kill a program with CTLR-C, and it's not working, try CTRL-\ instead.  Usually this will work.
+If you are trying to kill a program with :code:`CTLR-C`, and it's not working, try :code:`CTRL-\ ` instead.  Usually this will work.
 
 Is Your Raspberry Pi Locking Up?
 ################################


### PR DESCRIPTION
Currently, the docs show incorrect TOC content when accessing subpages, like below
![image](https://user-images.githubusercontent.com/5244214/116067657-a55d0800-a689-11eb-869e-7a7668aef948.png)

This PR fixes this issue + adds some content fixes as well

Now it looks like this (fixed)
![image](https://user-images.githubusercontent.com/5244214/116068012-02f15480-a68a-11eb-81b1-f2c0fc34d086.png)


Preview available here - https://luxonis-docs-website--183.com.readthedocs.build/en/183/pages/products/