### PR TITLE
Add mention about -db param

### DIFF
--- a/source/pages/calibration.rst
+++ b/source/pages/calibration.rst
@@ -67,18 +67,18 @@ please see the steps below and also :code:`./calibrate.py --help` which will pri
 
     Retrieve the size of the squares from the calibration target by measuring them with a ruler or calipers and enter that number (in cm) in place of [SQUARE_SIZE_IN_CM].
 
-    For example, the arguments for the :ref:`OAK-D <bw1098obc>` look like the following if the square size is 2.35 cm and a marker size is 1.90 cm:
+    For example, the arguments for the :ref:`OAK-D <bw1098obc>` look like the following if the square size is 2.35 cm:
 
     .. code-block:: bash
 
-      python3 calibrate.py -s 2.35 -ms 1.9 -brd bw1098obc -db
+      python3 calibrate.py -s 2.35 -brd bw1098obc -db
 
     And note that mirroring the display when calibrating is often useful (so that the directions of motion don't seem backwards).
     When seeing ourselves, we're used to seeing ourselves backwards (because that's what we see in a mirror), so do so, use the :code:`-ih` option as below:
 
     .. code-block:: bash
 
-      python3 calibrate.py -s 2.35 -ms 1.9 -brd bw1098obc -db -ih
+      python3 calibrate.py -s 2.35 -brd bw1098obc -db -ih
 
     So when we're running calibration internally we almost always use the :code:`-ih` option, so we'll include it on all the following example commands:
 

--- a/source/pages/calibration.rst
+++ b/source/pages/calibration.rst
@@ -57,13 +57,13 @@ please see the steps below and also :code:`./calibrate.py --help` which will pri
 
     .. code-block:: bash
 
-      python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -ms [MARKER_SIZE_IN_CM] -brd [BOARD]
+      python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -brd [BOARD] -db
 
     Argument reference:
 
     - :code:`-s SQUARE_SIZE_IN_CM`, :code:`--squareSizeCm SQUARE_SIZE_IN_CM`: Measure the square size of the printed charuco board in centimeters.
-    - :code:`-ms MARKER_SIZE_IN_CM`, :code:`--markerSizeCm MARKER_SIZE_IN_CM`: Measure the marker size of the printed charuco board in centimeters.
-    - :code:`-brd BOARD`, :code:`--board BOARD`: BW1097, BW1098OBC - Board type from resources/boards/ (not case-sensitive, if you're using OAK-D please choose BW1098OBC) or path to a custom .json board config.
+    - :code:`-db`, :code:`--defaultBoard`: flag that specifies that we're using a calibration board provided in depthai repository (from calib.io). If you're using other board, please instead specify :code:`-ms MARKER_SIZE_IN_CM`, :code:`--markerSizeCm MARKER_SIZE_IN_CM`: Marker size on the printed charuco board in centimeters.
+    - :code:`-brd BOARD`, :code:`--board BOARD`: BW1097, BW1098OBC - Device board type from resources/boards/ (not case-sensitive, if you're using OAK-D please choose BW1098OBC) or path to a custom .json board config.
 
     Retrieve the size of the squares from the calibration target by measuring them with a ruler or calipers and enter that number (in cm) in place of [SQUARE_SIZE_IN_CM].
 
@@ -71,14 +71,14 @@ please see the steps below and also :code:`./calibrate.py --help` which will pri
 
     .. code-block:: bash
 
-      python3 calibrate.py -s 2.35 -ms 1.9 -brd bw1098obc
+      python3 calibrate.py -s 2.35 -ms 1.9 -brd bw1098obc -db
 
     And note that mirroring the display when calibrating is often useful (so that the directions of motion don't seem backwards).
     When seeing ourselves, we're used to seeing ourselves backwards (because that's what we see in a mirror), so do so, use the :code:`-ih` option as below:
 
     .. code-block:: bash
 
-      python3 calibrate.py -s 2.35 -ms 1.9 -brd bw1098obc -ih
+      python3 calibrate.py -s 2.35 -ms 1.9 -brd bw1098obc -db -ih
 
     So when we're running calibration internally we almost always use the :code:`-ih` option, so we'll include it on all the following example commands:
 
@@ -86,13 +86,13 @@ please see the steps below and also :code:`./calibrate.py --help` which will pri
 
       .. code-block:: bash
 
-        python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -ms [MARKER_SIZE_IN_CM] -brd bw1098obc -ih
+        python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -db -brd bw1098obc -ih
 
     - **DepthAI RaspberryPi Compute Module:**
 
       .. code-block:: bash
 
-        python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -ms [MARKER_SIZE_IN_CM] -brd bw1097 -ih
+        python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -db -brd bw1097 -ih
 
 
 Modular cameras calibration
@@ -147,7 +147,7 @@ Then, run calibration with this board name:
 
 .. code-block:: bash
 
-  python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -ms [MARKER_SIZE_IN_CM] -brd ACME01 -ih
+  python3 calibrate.py -s [SQUARE_SIZE_IN_CM] -db -brd ACME01 -ih
 
 Run :code:`python3 calibrate.py --help` (or :code:`-h`) for a full list of arguments and usage examples.
 


### PR DESCRIPTION
`-db`, `--defaultBoard` param specifies that we're using a default calibration board from depthai repository (which is taken from calib.io). Allows to avoid measuring the markers themselves