### PR TITLE
Removed install_dependencies script

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python3 -m pip install -r requirements.txt


### PR DESCRIPTION
Removed install_dependencies script, since we use [the one in depthai-python](https://github.com/luxonis/depthai-python/blob/main/docs/source/_static/install_dependencies.sh). We have added alias to point to that script.