### PR TITLE
Fix broken link in calibration

### DIFF
--- a/source/pages/calibration.rst
+++ b/source/pages/calibration.rst
@@ -48,9 +48,9 @@ please see the steps below and also :code:`./calibrate.py --help` which will pri
 
     Often, using a monitor to display the calibration target is easier/faster.
 
-    .. image:: https://github.com/luxonis/depthai/raw/main/charuco_297x210_8x11_20_DICT_4X4.png
+    .. image:: https://github.com/luxonis/depthai/blob/2402db26408da6a122d9ae9ae646b0d96ea7e1d9/charuco_11x8.pdf
       :alt: Print this charuco calibration image
-      :target: https://github.com/luxonis/depthai/raw/main/charuco_297x210_8x11_20_DICT_4X4.png
+      :target: https://github.com/luxonis/depthai/blob/2402db26408da6a122d9ae9ae646b0d96ea7e1d9/charuco_11x8.pdf
 
     The entire board should fit on a single piece of paper (scale to fit).  And if displaying on a monitor, full-screen the image with a white background.
 


### PR DESCRIPTION
When linking to github repo, it's preferred to link to commit, instead branch.
In this case the file was removed from `main` branch, thus the link got broken.
Linking to specific commit doesn't have such issues (except if we rewrite the whole history).
