### PR TITLE
Update grep term

### DIFF
--- a/source/pages/tutorials/first_steps.rst
+++ b/source/pages/tutorials/first_steps.rst
@@ -31,7 +31,7 @@ On Ubuntu, you can check if a new USB device was detected by running
 
 .. code-block:: bash
 
-  $ lsusb | grep MyriadX
+  $ lsusb | grep 03e7
   Bus 003 Device 002: ID 03e7:2485 Intel Movidius MyriadX
 
 .. note::


### PR DESCRIPTION
Instead of grepping for `MyriadX` (which may not be present in lsusb's output depending on udev rules), grep for `03e7` (the Intel Movidius VID)