### PR TITLE
Fix troubleshooting.rst formatting directives

### DIFF
--- a/source/pages/troubleshooting.rst
+++ b/source/pages/troubleshooting.rst
@@ -257,10 +257,15 @@ This so far has always meant there is a problem with the OpenCV install on the h
 
   python3 -c "import cv2; import numpy as np; blank_image = np.zeros((500,500,3), np.uint8); cv2.imshow('s', blank_image); cv2.waitKey(0)"
 
-If a window is not displayed, or if you get the `:bash: Illegal instruction` result, this means there is a problem with
+If a window is not displayed, or if you get the :code:`Illegal instruction` result, this means there is a problem with
 the OpenCV install.  The installation scripts `here <https://docs.luxonis.com/en/latest/pages/api/#supported-platforms>`__
 often will fix the OpenCV issues.  But if they do not, running
-`:bash: python3 -m pip install opencv-python --force-reinstall` will often fix the OpenCV problem.
+
+.. code-block:: bash
+
+  python3 -m pip install opencv-python --force-reinstall
+
+will often fix the OpenCV problem.
 
 Neural network blob compiled with incompatible openvino version
 ###############################################################


### PR DESCRIPTION
While scrolling through the [Troubleshooting section](https://docs.luxonis.com/en/latest/pages/troubleshooting/), I noticed two formatting issues under "python3 depthai_demo.py returns Illegal instruction"

![image](https://github.com/luxonis/depthai-docs-website/assets/5244214/4422e8f4-da40-4f49-9ca0-dbe2211a7b0a)

This PR fixes incorrect `:bash:` directives with `:code:` in one case and `.. code-block:: bash` in the other
